### PR TITLE
Bind the parameters also to initial_state/1 generator

### DIFF
--- a/src/qc_statem_impl.erl
+++ b/src/qc_statem_impl.erl
@@ -94,7 +94,7 @@ qc_prop(Options) ->
     NewOptions = proplists:delete(timeout, proplists:delete(sometimes, proplists:delete(parallel, proplists:delete(name, Options)))),
     Params = [{parallel,Parallel}, {mod,MOD}, {options,NewOptions}],
     ?FORALL(Scenario,with_parameters(Params,scenario()),
-            ?LET(S0,initial_state(Scenario),
+            ?LET(S0,with_parameters(Params,initial_state(Scenario)),
                  qc_prop1(Parallel, Start, Options, Name, Sometimes, Timeout, Scenario, Params, S0))).
 
 %%%----------------------------------------------------------------------


### PR DESCRIPTION
With this change, you can get the QuickCheck run options not only inside Mod:scenario_gen/0 but also inside Mod:initial_state/1.

``` erlang
initial_state(Scenario) ->
    ?LET(Parallel,parameter(parallel,false),
         ?LET(Options,parameter(options,[]),
```
