### PR TITLE
Support eqc 1.33

### DIFF
--- a/src/qc_statem.erl
+++ b/src/qc_statem.erl
@@ -22,6 +22,7 @@
 
 -ifdef(QC).
 
+-eqc_group_commands(false).
 -include("qc_statem.hrl").
 
 -ifdef(QC_STATEM).
@@ -155,7 +156,18 @@ qc_prop1(Mod, Opts, Start, Name, false, _Sometimes, Timeout) ->
                                     {H,S,Res} = run_commands(Mod, Cmds, Opts),
 
                                     %% history
-                                    Fun = fun({Cmd,{State,Reply}},{N,Acc}) -> {N+1,[{N,Cmd,Reply,State}|Acc]} end,
+                                    Fun = fun({Cmd,H1},{N,Acc}) ->
+                                                  case H1 of
+                                                      %% eqc 1.33
+                                                      {eqc_statem_history,State,_,_,{_, Reply}} ->
+                                                          ok;
+                                                      %% eqc 1.26
+                                                      {State,Reply} ->
+                                                          ok
+                                                  end,
+                                                  {N+1,[{N,Cmd,Reply,State}|Acc]} end,
+
+
                                     {_, RevCmdsH} = lists:foldl(Fun, {1,[]}, zip(tl(Cmds),H)),
                                     CmdsH = lists:reverse(RevCmdsH),
 


### PR DESCRIPTION
Hi,

I have upgraded eqc from 1.26 to 1.33 and found that the following changes in qc_statem module were necessary.
1. Add `-eqc_group_commands(false)` to qc_statem to disable the parse transform for grouped style callback functions (*1).
2. eqc 1.33's `run_commands function` returns a different history (*2). Support both history tuples in eqc 1.33 and 1.26.

Tested with both eqc 1.33 and 1.26.

---

***1:** (From the reference manual)

> Module **eqc_group_commands**
> 
> This parse transformation is used with QuickCheck state machines to enable specifications to be written in a different style, the "grouped" style. This may result in shorter, more readable specifications in certain cases. However, one should be warned that the parse transformation may cause some difficulty in debugging such specifications, because the compiled code no longer corresponds exactly to the source code.
> 
> What the parse transformation does is to offer a new set of call-back functions to define QuickCheck state machines with. This parse transformation is automatically invoked by eqc_statem.hrl, and recognizes a grouped specification by the absence of a `command/1` function in the module, or by the optional user annotation `-eqc_group_commands(true)`.
> 
> Note that you cannot mix the old call-back functions with the new call-back functions. Either you use the grouped style, or you use the call-backs as defined in the original QuickCheck state machine descriptions.

***2:** (From the Release Notes)

> Release notes for 1.33.1
> 
> One major change that breaks backward compatibility.
> The `run_commands` function returns a different history. Thus, if your QuickCheck specification, against all odds, uses the H in the return tuple `{H, S, Res}`, then you might need to update the specification. 
